### PR TITLE
feat(llm): default to ollama with timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ Create a `.env` file in the project root with the following:
 OPENAI_API_KEY=<your_openai_api_key>
 EMAIL_ADDRESS=<your_email_address>
 EMAIL_SMTP_PROFILE=gmail  # msmtp profile name
+LOCAL_AI_IP=127.0.0.1       # Ollama host
+OLLAMA_PORT=11434           # Ollama API port
 ```
+
+The application defaults to using a local [Ollama](https://ollama.com) server
+for language model interactions via its OpenAI-compatible `/v1` API.
+Set `LOCAL_AI_IP` and `OLLAMA_PORT` to match
+your environment if the defaults differ.
 
 ### 4. Configure msmtp
 Ensure msmtp is configured correctly for sending emails. Example configuration in `~/.msmtprc`:

--- a/config.py
+++ b/config.py
@@ -39,8 +39,10 @@ TEXTGEN_PORT = os.getenv("TEXTGEN_PORT", "5150")
 # Whether to use a locally hosted language model
 USE_LOCAL_LLM = os.getenv("USE_LOCAL_LLM", "true").lower() in {"1", "true", "yes"}
 
-# Base URL for the local text generation server
-LOCAL_AI_BASE_URL = f"http://{LOCAL_AI_IP}:{TEXTGEN_PORT}"
+# Base URLs for local model servers
+OLLAMA_BASE_URL = f"http://{LOCAL_AI_IP}:{OLLAMA_PORT}"
+# Maintained for backward compatibility
+LOCAL_AI_BASE_URL = OLLAMA_BASE_URL
 ANYTHING_API_URL = os.getenv("ANYTHING_API_URL")
 ANYTHING_API_KEY = os.getenv("ANYTHING_API_KEY")
 

--- a/get_models.py
+++ b/get_models.py
@@ -1,10 +1,10 @@
-"""Utility script to list available models on the local text generation server."""
+"""Utility script to list available models on the local Ollama server."""
 
 import requests
 
-from config import LOCAL_AI_BASE_URL
+from config import OLLAMA_BASE_URL
 
-list_models_endpoint = f"{LOCAL_AI_BASE_URL}/v1/internal/model/info"
+list_models_endpoint = f"{OLLAMA_BASE_URL}/v1/models"
 
-response = requests.get(list_models_endpoint)
+response = requests.get(list_models_endpoint, timeout=5)
 print(response.json())

--- a/gpt_api.py
+++ b/gpt_api.py
@@ -101,7 +101,7 @@ def call_ollama_embedding(text, model="nomic-embed-text"):
         return {"error": str(e)}
 
 
-def call_ollama_llm(prompt, model="llama3.1"):
+def call_ollama_llm(prompt, model="qwen2.5-coder:0.5b"):
     """Send a chat request to the local Ollama server."""
     try:
         url = f"{OLLAMA_BASE_URL}/v1/chat/completions"

--- a/gpt_api.py
+++ b/gpt_api.py
@@ -105,11 +105,9 @@ def call_ollama_llm(prompt, model="qwen2.5-coder:0.5b"):
     """Send a chat request to the local Ollama server."""
     try:
         url = f"{OLLAMA_BASE_URL}/v1/chat/completions"
-        console.print(
-            f"[blue]Sending to Ollama at: {url}\n Message: {prompt}[/blue]"
-        )
+        console.print(f"[blue]Sending to Ollama at: {url}\n Message: {prompt}[/blue]")
         payload = {"model": model, "messages": [{"role": "user", "content": prompt}]}
-        response = requests.post(url, json=payload, timeout=60)
+        response = requests.post(url, json=payload, timeout=360)
         response.raise_for_status()
         return response.json()
     except Exception as e:
@@ -163,9 +161,7 @@ def ask_gpt(prompt, model=None):
             api_response = call_ollama_llm(prompt, model=model_to_use)
             elapsed = time.perf_counter() - start
             formatted_response = format_api_response(api_response)
-            log_gpt_request(
-                prompt, api_response, token_count, elapsed, model_to_use
-            )
+            log_gpt_request(prompt, api_response, token_count, elapsed, model_to_use)
             return formatted_response
         except Exception as e:
             logging.error(f"Error during Ollama call: {e}")
@@ -184,9 +180,7 @@ def ask_gpt(prompt, model=None):
             )
             elapsed = time.perf_counter() - start
             api_dict = api_response.model_dump()
-            log_gpt_request(
-                prompt, api_dict, token_count, elapsed, model_to_use
-            )
+            log_gpt_request(prompt, api_dict, token_count, elapsed, model_to_use)
             return format_api_response(api_dict)
         except Exception as e:
             logging.error(f"Error during GPT API call: {e}")


### PR DESCRIPTION
## Summary
- default local model calls to Ollama
- track model name and request timing for performance comparisons
- document Ollama environment variables and OpenAI-compatible `/v1` endpoints

## Testing
- `python -m py_compile config.py gpt_api.py get_models.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5304f2364832985428aad7807d5b0