### PR TITLE
refactor: rename local LLM flag

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,9 @@
-# config.py
+"""Configuration settings for EmailAssistant.
+
+This module loads environment variables and centralizes paths, mail settings,
+and model selection flags used across the project.
+"""
+
 import os
 from dotenv import load_dotenv
 
@@ -26,7 +31,8 @@ IMAP_USER = os.getenv("IMAP_USER")
 IMAP_PASS = os.getenv("IMAP_PASS")
 
 # LLM Configuration
-USE_LOCAL_LLM = "true"
+# Determines whether to use a locally hosted model or the OpenAI API.
+USE_LOCAL_LLM = os.getenv("USE_LOCAL_LLM", "false").lower() == "true"
 
 LOCAL_AI_BASE_URL = os.getenv("LOCAL_AI_URL")
 ANYTHING_API_URL = os.getenv("ANYTHING_API_URL")

--- a/embedding_engine.py
+++ b/embedding_engine.py
@@ -1,16 +1,24 @@
-# embedding_engine.py
+"""Utilities for generating text embeddings.
+
+This module provides helpers to obtain embeddings from either OpenAI or a
+locally hosted model. The choice is controlled by the ``USE_LOCAL_LLM`` flag in
+``config.py``.
+"""
+
 import os
 import requests
 import logging
 import openai
 from dotenv import load_dotenv
-from config import USE_LOCALAI, LOCAL_AI_BASE_URL
+from config import USE_LOCAL_LLM, LOCAL_AI_BASE_URL
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 
 def embed_with_openai(text):
+    """Return an embedding for ``text`` using OpenAI."""
+
     try:
         response = openai.Embedding.create(model="text-embedding-3-small", input=text)
         return response["data"][0]["embedding"]
@@ -20,6 +28,8 @@ def embed_with_openai(text):
 
 
 def embed_with_local_model(text):
+    """Return an embedding for ``text`` using a locally hosted model."""
+
     try:
         url = f"{LOCAL_AI_BASE_URL}/v1/embeddings"
         payload = {"model": "nomic-embed-text-v1.5", "input": text}
@@ -32,13 +42,16 @@ def embed_with_local_model(text):
 
 
 def embed_text(text):
-    if USE_LOCALAI:
+    """Embed ``text`` using the configured provider."""
+
+    if USE_LOCAL_LLM:
         return embed_with_local_model(text)
     return embed_with_openai(text)
 
 
-# Optional utility to embed a file as text
 def embed_file_as_text(filepath):
+    """Embed the contents of ``filepath`` as plain text."""
+
     try:
         with open(filepath, "r", encoding="utf-8") as f:
             content = f.read()


### PR DESCRIPTION
## Summary
- replace `USE_LOCALAI` with `USE_LOCAL_LLM`
- derive local vs OpenAI embedding from `config.USE_LOCAL_LLM`
- document config and embedding utilities
- delegate run-mail embeddings to `embedding_engine`

## Testing
- `ruff check config.py embedding_engine.py run_mail/run_mail.py`
- `black --check config.py embedding_engine.py run_mail/run_mail.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897089300688329993337a39718a6b5