### PR TITLE
feat: display active ai provider

### DIFF
--- a/gpt_api.py
+++ b/gpt_api.py
@@ -13,8 +13,14 @@ import logging
 import tiktoken
 import time
 from datetime import datetime
+from urllib.parse import urlparse
 from dotenv import load_dotenv
-from config import USE_LOCAL_LLM, OLLAMA_BASE_URL
+from config import (
+    USE_LOCAL_LLM,
+    OLLAMA_BASE_URL,
+    OLLAMA_PORT,
+    TEXTGEN_PORT,
+)
 from rich.console import Console
 
 # Setup rich console for pretty output
@@ -185,6 +191,47 @@ def ask_gpt(prompt, model=None):
         except Exception as e:
             logging.error(f"Error during GPT API call: {e}")
             return None
+
+
+def get_active_provider():
+    """Return a descriptive name for the configured language model provider.
+
+    Returns
+    -------
+    str
+        Human readable identifier describing the provider that will handle
+        language model requests (e.g., ``"Ollama"`` or ``"OpenAI"``).
+    """
+
+    if USE_LOCAL_LLM:
+        return "Ollama"
+
+    if BASE_URL:
+        normalized_url = BASE_URL.lower()
+        try:
+            parsed_url = urlparse(BASE_URL)
+            detected_port = str(parsed_url.port) if parsed_url.port else ""
+        except ValueError:
+            detected_port = ""
+
+        textgen_signatures = ("textgen", "text-generation-webui", "oobabooga")
+        if any(signature in normalized_url for signature in textgen_signatures) or (
+            detected_port == str(TEXTGEN_PORT)
+        ):
+            return "textgeneration-webui"
+
+        if "ollama" in normalized_url or detected_port == str(OLLAMA_PORT):
+            return "Ollama"
+
+        if "openai" in normalized_url:
+            return "OpenAI"
+
+        return "Other"
+
+    if API_KEY:
+        return "OpenAI"
+
+    return "Unknown"
 
 
 def get_active_model():

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from summarize import apply_filter_rules, reply_to_email, search_emails
 from draft_reply import generate_draft_reply
 from mail_rules import interactive_rule_application
 from batch_cleanup import batch_cleanup_analysis
+from gpt_api import get_active_provider
 
 console = Console()
 
@@ -120,7 +121,17 @@ def clear_archive():
 
 
 def print_menu():
-    table = Table(title="📌 Email Assistant Menu", style="bold green")
+    """Render the main menu table with the active AI provider.
+
+    Returns:
+        None: The menu output is written directly to the console.
+    """
+
+    provider = get_active_provider()
+    table = Table(
+        title=f"📌 Email Assistant Menu • Provider: {provider}",
+        style="bold green",
+    )
     table.add_column("Option", style="bold cyan")
     table.add_column("Action", style="bold white")
 


### PR DESCRIPTION
## Summary
- add a provider detection helper in `gpt_api.get_active_provider` to classify the configured LLM backend
- surface the detected provider in the Email Assistant menu title so the active AI backend is visible at a glance

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf8b967b8883298bc289a316b34fce